### PR TITLE
Add Travis-CI functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ rvm:
 
 install:
   - gem install jekyll
+  - gem install html-proofer
 
 script:
   - jekyll build
-  #- htmlproof ./_site
+  - htmlproof ./_site


### PR DESCRIPTION
These changes allow Travis-CI functionality by adding a `.travis.yml` file set up to test that the pages can be built with Jekyll and then checks the HTML with HTML Proofer.
