### PR TITLE
Speed up build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-rvm: 2.1.1
+rvm: 2.1
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
-rvm:
-  - 2.1
+rvm: 2.1.1
+
+env:
+  global:
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true  # speeds up installation of html-proofer
 
 install:
   - gem install jekyll

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true  # speeds up installation of html-proofer
 
 install:
-  - gem install jekyll
-  - gem install html-proofer
+  # Skip document generation to speed up install
+  - gem install jekyll --no-document
+  - gem install html-proofer --no-document
 
 script:
   - jekyll build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true  # speeds up installation of html-proofer
 
 install:
-  # Skip document generation to speed up install
-  - gem install jekyll --no-document
-  - gem install html-proofer --no-document
+  - gem install jekyll
+  - gem install html-proofer
 
 script:
   - jekyll build


### PR DESCRIPTION
This adds a global environment varaible that makes `html-proofer` use the system libraries, instead of compiling them itself, which knocks over a minute off the build time, reducing it to a total build time of under a minute.