### PR TITLE
Travis and htmlproofer fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-rvm: 2.1
+rvm: 2.3.3
 
 sudo: false
 cache: bundler
@@ -9,4 +9,4 @@ env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true  # speeds up installation of html-proofer
 
 script:
-  - bundle exec jekyll build && bundle exec htmlproof ./_site
+  - bundle exec jekyll build && bundle exec htmlproofer ./_site

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'jekyll'
+gem 'github-pages', group: :jekyll_plugins
 gem 'html-proofer'

--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@ exclude: [vendor]
 
 # Build settings
 markdown: kramdown
-permalink: /:categories/:title
+permalink: /:categories/:title/
 excerpt_separator: <!--more--> #use this in posts to define how long the excerpt of the post (that is shown on the Blog page) is
 
 colors:  #in hex code if not noted else

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -10,7 +10,8 @@ layout: page
         <h2>{{ post.title }}</h2>
         <p> Tags: 
             {% for tag in post.tags %}
-                <a href="/tag/{{tag}}/">{{tag}} </a>
+                <!--<a href="/tag/{{ tag }}/">{{ tag }}</a>-->
+                {{ tag }}
             {% endfor %} 
         </p>
         <p class="blogdate">{{ post.date | date: "%d %B %Y" }}</p>
@@ -30,7 +31,8 @@ layout: page
         <h2>{{ post.title }}</h2> 
         <p> Tags: 
             {% for tag in post.tags %}
-                <a href="/tag/{{tag}}/">{{tag}} </a>
+                <!--<a href="/tag/{{ tag }}/">{{ tag }}</a>-->
+                {{ tag }}
             {% endfor %} 
         </p>  
         <p class="blogdate">{{ post.date | date: "%d %B %Y" }}</p>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -8,6 +8,8 @@ layout: page
     {% for post in site.posts limit:1 %}
         <a href="{{ post.url }}/">
         <h2>{{ post.title }}</h2>
+            <h2>{{ post.title }}</h2>
+        </a>
         <p> Tags: 
             {% for tag in post.tags %}
                 <!--<a href="/tag/{{ tag }}/">{{ tag }}</a>-->
@@ -16,7 +18,6 @@ layout: page
         </p>
         <p class="blogdate">{{ post.date | date: "%d %B %Y" }}</p>
         <div>{{ post.content |truncatehtml | truncatewords: 60 }}</div>
-        </a>
     {% endfor %}
     </table>
 </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -26,7 +26,8 @@ layout: default
                     <h1>Latest News</h1>
                     {% for post in site.posts limit:1 %}
                         <a href="{{ post.url }}/">
-                        <h2>{{ post.title }}</h2>
+                            <h2>{{ post.title }}</h2>
+                        </a>
                         <p> Tags: 
                             {% for tag in post.tags %}
                                 <!--<a href="/tag/{{ tag }}/">{{ tag }}</a>-->
@@ -35,7 +36,6 @@ layout: default
                         </p>
                         <p class="blogdate">{{ post.date | date: "%d %B %Y" }}</p>
                         <div>{{ post.excerpt |truncatehtml | truncatewords: 60 }}</div>
-                        </a>
                     {% endfor %}
             </div>
         </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -29,7 +29,8 @@ layout: default
                         <h2>{{ post.title }}</h2>
                         <p> Tags: 
                             {% for tag in post.tags %}
-                                <a href="/tag/{{tag}}/">{{tag}} </a>
+                                <!--<a href="/tag/{{ tag }}/">{{ tag }}</a>-->
+                                {{ tag }}
                             {% endfor %} 
                         </p>
                         <p class="blogdate">{{ post.date | date: "%d %B %Y" }}</p>

--- a/_layouts/news-list.html
+++ b/_layouts/news-list.html
@@ -5,7 +5,7 @@ layout: page
 <ul>
     {% for post in site.posts %}
     <li>
-        <a class="btn btn-theme" href="{{ ../post.url }}/">{{post.date | date:"%d/%m/%Y"}} - {{ post.title}}</a>
+        <a class="btn btn-theme" href="{{ post.url }}/">{{post.date | date:"%d/%m/%Y"}} - {{ post.title}}</a>
     </li>
     {% endfor %}
 </ul>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -19,7 +19,8 @@ layout: page
     <div class="row centered">
         <p> Tags: 
             {% for tag in page.tags %}
-                <a href="/tag/{{tag}}/">{{tag}} </a>
+                <!--<a href="/tag/{{ tag }}/">{{ tag }}</a>-->
+                {{ tag }}
             {% endfor %} 
         </p>
     </div>

--- a/_posts/2015-02-05-pages-overhaul.md
+++ b/_posts/2015-02-05-pages-overhaul.md
@@ -3,8 +3,7 @@ layout: post
 title: Pages Overhaul
 author: Adrian Coveney
 tags:
-- Update
+- update
 ---
 
 Welcome to the newly overhauled APEL GitHub Pages.
-<!--more-->


### PR DESCRIPTION
This fixes the broken build which was mainly due to an old version of Ruby being set causing a package to fail to install, and Jekyll 3.x being different to Jekyll 2.x in that it now [does not automatically apply trailing slashes to permalinks](http://jekyllrb.com/docs/upgrading/2-to-3/#permalinks-no-longer-automatically-add-a-trailing-slash) causing htmlproofer to complain about dead links.

Some other minor fixes and tweaks applied as well.